### PR TITLE
Fix/integration test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
           pytest tests/integration --cov=src --cov-report=xml --disable-warnings
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage.xml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,6 @@ on:
     branches:
       - 'main'
       - 'develop'
-      - 'fix/integration-test'
   pull_request:
     branches:
       - 'main'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,13 +4,16 @@ on:
   push:
     branches:
       - 'main'
+      - 'develop'
+      - 'fix/integration-test'
   pull_request:
     branches:
       - 'main'
+      - 'develop'
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: F74144781
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           cd backend
-          pytest tests/integration --cov=src --cov-report=xml --disable-warnings
+          pytest tests/* --cov=src --cov-report=xml --disable-warnings
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ __pycache__
 .vscode
 .venv
 backend/news_database.db
+
+
+.coverage
+coverage.xml
+test.db
+test-report.html
+backend/assets/**

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -71,7 +71,7 @@ tldextract==5.1.2
 tomli==2.0.1
 tqdm==4.66.4
 typer==0.12.3
-typing_extensions==4.12.2
+typing_extensions
 tzdata==2024.1
 tzlocal==5.2
 ujson==5.10.0

--- a/backend/src/database.py
+++ b/backend/src/database.py
@@ -153,6 +153,9 @@ class NewsArticleRepository:
             self.db.commit()
             return "Article upvoted"
 
+    def find_by_url(self, url: str) -> NewsArticle | None:
+        return self.db.query(NewsArticle).filter_by(url=url).first()
+
 
 # Global database instance
 db_instance = Database()

--- a/backend/src/news/router.py
+++ b/backend/src/news/router.py
@@ -59,6 +59,13 @@ async def search_news(request: PromptRequest, db: Session = Depends(get_db)):
     """
     news_processor = NewsProcessor(db, OPENAI_API_KEY)
     results = news_processor.search_news_by_prompt(request.prompt)
+
+    if not results:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No news articles found for the given prompt",
+        )
+
     return results
 
 

--- a/backend/src/news/router.py
+++ b/backend/src/news/router.py
@@ -5,7 +5,11 @@ from sqlalchemy.orm import Session
 
 from ..database import NewsArticle, NewsArticleRepository, User, get_db
 from ..user.service import auth_service
-from .schemas import NewsSummaryRequestSchema, PromptRequest
+from .schemas import (
+    NewsSearchResultSchema,
+    NewsSummaryRequestSchema,
+    PromptRequest,
+)
 from .service import NewsProcessor
 
 router = APIRouter(prefix="/api/v1/news", tags=["news"])
@@ -47,13 +51,15 @@ def read_user_news(
     return result
 
 
-@router.post("/search_news")
+@router.post("/search_news", response_model=list[NewsSearchResultSchema])
 async def search_news(request: PromptRequest, db: Session = Depends(get_db)):
-    raise HTTPException(
-        status_code=status.HTTP_404_NOT_FOUND,
-        detail="This search endpoint is deprecated. "
-        "News is now fetched automatically.",
-    )
+    """
+    Search for news articles based on a user prompt.
+    Uses AI to extract keywords and fetches detailed article content.
+    """
+    news_processor = NewsProcessor(db, OPENAI_API_KEY)
+    results = news_processor.search_news_by_prompt(request.prompt)
+    return results
 
 
 @router.post("/news_summary")

--- a/backend/src/news/schemas.py
+++ b/backend/src/news/schemas.py
@@ -7,3 +7,12 @@ class PromptRequest(BaseModel):
 
 class NewsSummaryRequestSchema(BaseModel):
     content: str
+
+
+class NewsSearchResultSchema(BaseModel):
+    """Schema for news search results returned by the search_news endpoint."""
+
+    url: str
+    title: str
+    time: str
+    content: str

--- a/backend/src/news/service.py
+++ b/backend/src/news/service.py
@@ -42,6 +42,32 @@ class NewsProcessor:
 
         return all_news_data
 
+    def _extract_keywords(self, prompt: str) -> str | None:
+        """Extract keywords from user prompt using OpenAI."""
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "你是一個關鍵字提取機器人，用戶將會輸入一段文字，"
+                    "表示其希望看見的新聞內容，請提取出用戶希望看見的關鍵字，"
+                    "請截取最重要的關鍵字即可，避免出現「新聞」、「資訊」等混淆搜尋引擎的字詞。"
+                    "(僅須回答關鍵字，若有多個關鍵字，請以空格分隔)"
+                ),
+            },
+            {"role": "user", "content": prompt},
+        ]
+
+        try:
+            completion = self.ai_client.chat.completions.create(
+                model="gpt-3.5-turbo",
+                messages=messages,
+            )
+            keywords = completion.choices[0].message.content
+            return keywords.strip() if keywords else None
+        except Exception as e:
+            print(f"Error extracting keywords with OpenAI: {e}")
+            return None
+
     def _check_relevance(self, title: str) -> bool:
         messages = [
             {
@@ -161,3 +187,50 @@ class NewsProcessor:
             self.news_repo.add_article(detailed_news)
 
             print(f"Added article: {detailed_news['title']}")
+
+    def search_news_by_prompt(self, prompt: str) -> list[dict]:
+        """
+        Search for news articles based on a user prompt.
+
+        1. Extract keywords from the prompt using AI
+        2. Fetch news articles using those keywords
+        3. Scrape detailed content from each article
+        4. Return sorted results by time
+        """
+        # Step 1: Extract keywords from prompt
+        keywords = self._extract_keywords(prompt)
+        if not keywords:
+            print("Failed to extract keywords from prompt")
+            return []
+
+        print(f"Extracted keywords: {keywords}")
+
+        # Step 2: Fetch news items using the extracted keywords
+        news_items = self._fetch_news_from_api(keywords, is_initial=False)
+        if not news_items:
+            print("No news items found")
+            return []
+
+        # Step 3: Scrape detailed content from each article
+        news_list = []
+        for item in news_items:
+            url = item.get("titleLink")
+            if not url:
+                continue
+
+            try:
+                detailed_news = self._scrape_article_details(url)
+                if not detailed_news:
+                    continue
+
+                # Join content paragraphs into a single string
+                detailed_news["content"] = " ".join(
+                    detailed_news.get("content", [])
+                )
+                news_list.append(detailed_news)
+            except Exception as e:
+                print(f"Error processing article {url}: {e}")
+                continue
+
+        # Step 4: Sort by time (newest first) and return
+        return sorted(news_list, key=lambda x: x.get("time", ""), reverse=True)

--- a/backend/src/news/service.py
+++ b/backend/src/news/service.py
@@ -230,7 +230,9 @@ class NewsProcessor:
                 )
                 news_list.append(detailed_news)
             except Exception as e:
-                print(f"Error processing article {url}: {e}")
+                print(
+                    f"Error processing article {url} [{type(e).__name__}]: {e}"
+                )
                 continue
 
         # Step 4: Sort by time (newest first) and return

--- a/backend/src/news/service.py
+++ b/backend/src/news/service.py
@@ -3,8 +3,9 @@ from urllib.parse import quote
 
 import requests
 from bs4 import BeautifulSoup
-from openai import OpenAI
 from sqlalchemy.orm import Session
+
+from openai import OpenAI
 
 from ..database import NewsArticleRepository
 
@@ -200,7 +201,7 @@ class NewsProcessor:
         # Step 1: Extract keywords from prompt
         keywords = self._extract_keywords(prompt)
         if not keywords:
-            print("Failed to extract keywords from prompt")
+            print(f"Failed to extract keywords from prompt: {prompt}")
             return []
 
         print(f"Extracted keywords: {keywords}")

--- a/backend/tests/news/test_news_endpoint.py
+++ b/backend/tests/news/test_news_endpoint.py
@@ -1,4 +1,6 @@
 import json
+import os
+import shutil
 from unittest.mock import Mock
 
 import pytest
@@ -7,21 +9,23 @@ from jose import jwt
 from sqlalchemy import StaticPool, create_engine
 from sqlalchemy.orm import sessionmaker
 
-from main import (
+from main import app
+from src.database import (
+    USER_NEWS_ASSOCIATION_TABLE as USER_NEWS_ASSOCIATION_TABLE,
+)
+from src.database import (
     Base,
     NewsArticle,
-    NewsSumaryRequestSchema,
-    PromptRequest,
     User,
-    app,
-    pwd_context,
-    session_opener,
-    user_news_association_table,
+    get_db,
 )
+from src.news.schemas import NewsSummaryRequestSchema
+from src.user.service import auth_service
 
 SECRET_KEY = "1892dhianiandowqd0n"
 ALGORITHM = "HS256"
 SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+DATABASE_FILE = "./test.db"
 engine = create_engine(
     SQLALCHEMY_DATABASE_URL,
     connect_args={"check_same_thread": False},
@@ -41,7 +45,7 @@ def override_session_opener():
         db.close()
 
 
-app.dependency_overrides[session_opener] = override_session_opener
+app.dependency_overrides[get_db] = override_session_opener
 client = TestClient(app)
 
 
@@ -54,7 +58,7 @@ def clear_users():
 
 @pytest.fixture(scope="module")
 def test_user(clear_users):
-    hashed_password = pwd_context.hash("testpassword")
+    hashed_password = auth_service.get_password_hash("testpassword")
 
     with next(override_session_opener()) as db:
         user = User(username="testuser", hashed_password=hashed_password)
@@ -104,6 +108,13 @@ def test_user_and_articles(test_user, test_articles):
     return test_user, test_articles
 
 
+@pytest.fixture(scope="session", autouse=True)
+def cleanup():
+    yield
+    if os.path.exists(DATABASE_FILE):
+        os.remove(DATABASE_FILE)
+
+
 def test_read_news(test_articles):
     response = client.get("/api/v1/news/news")
     assert response.status_code == 200
@@ -128,7 +139,7 @@ def test_read_user_news(test_user, test_token, test_articles):
 
 
 def mock_openai(mocker, return_content):
-    mock_openai_client = mocker.patch("main.OpenAI")
+    mock_openai_client = mocker.patch("src.news.service.OpenAI")
 
     mock_message = Mock()
     mock_message.content = return_content
@@ -147,17 +158,18 @@ def mock_openai(mocker, return_content):
 
 
 def test_search_news(mocker):
-    mock_openai(mocker, "keywords")
+    # Mock OpenAI keyword extraction
+    mock_openai(mocker, "雞蛋 價格")
 
-    mock_get_new_info = mocker.patch(
-        "main.get_new_info",
+    # Mock the UDN API response (_fetch_news_from_api)
+    mock_fetch_api = mocker.patch(
+        "src.news.service.NewsProcessor._fetch_news_from_api",
         return_value=[{"titleLink": "http://example.com/news1"}],
     )
 
-    mock_get = mocker.patch(
-        "main.requests.get",
-        return_value=mocker.Mock(
-            text="""
+    # Mock requests.get for article scraping
+    mock_response = mocker.Mock()
+    mock_response.text = """
         <html>
         <h1 class="article-content__title">Test Title</h1>
         <time class="article-content__time">2024-09-10</time>
@@ -166,7 +178,11 @@ def test_search_news(mocker):
         </section>
         </html>
         """
-        ),
+    mock_response.raise_for_status = mocker.Mock()
+
+    mock_get = mocker.patch(
+        "src.news.service.requests.get",
+        return_value=mock_response,
     )
 
     request_body = {"prompt": "Test search prompt"}
@@ -181,6 +197,10 @@ def test_search_news(mocker):
     assert data[0]["time"] == "2024-09-10"
     assert data[0]["content"] == "This is a test paragraph."
 
+    # Verify the mock calls
+    mock_fetch_api.assert_called_once_with("雞蛋 價格", is_initial=False)
+    mock_get.assert_called_once_with("http://example.com/news1", timeout=10)
+
 
 def test_news_summary(mocker, test_token):
     headers = {"Authorization": f"Bearer {test_token}"}
@@ -189,7 +209,7 @@ def test_news_summary(mocker, test_token):
     )
     mock_openai(mocker, openai_response)
 
-    request_body = NewsSumaryRequestSchema(content="Test news content")
+    request_body = NewsSummaryRequestSchema(content="Test news content")
     response = client.post(
         "/api/v1/news/news_summary", json=request_body.dict(), headers=headers
     )

--- a/backend/tests/news/test_news_endpoint.py
+++ b/backend/tests/news/test_news_endpoint.py
@@ -1,6 +1,5 @@
 import json
 import os
-import shutil
 from unittest.mock import Mock
 
 import pytest

--- a/backend/tests/news/test_news_endpoint.py
+++ b/backend/tests/news/test_news_endpoint.py
@@ -10,9 +10,7 @@ from sqlalchemy.orm import sessionmaker
 
 from main import app
 from src.database import (
-    USER_NEWS_ASSOCIATION_TABLE as USER_NEWS_ASSOCIATION_TABLE,
-)
-from src.database import (
+    USER_NEWS_ASSOCIATION_TABLE,
     Base,
     NewsArticle,
     User,

--- a/backend/tests/prices/test_price_endpoint.py
+++ b/backend/tests/prices/test_price_endpoint.py
@@ -1,5 +1,6 @@
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
+import httpx
 import pytest
 from fastapi.testclient import TestClient
 
@@ -32,11 +33,16 @@ def mock_necessities_data():
     ]
 
 
-@patch("main.requests.get")
-def test_get_necessities_prices(mock_get, mock_necessities_data):
-    mock_response = mock_get.return_value
-    mock_response.status_code = 200
-    mock_response.json.return_value = mock_necessities_data
+@patch("src.prices.router.httpx.AsyncClient")
+def test_get_necessities_prices(mock_async_client, mock_necessities_data):
+    mock_response = httpx.Response(
+        200,
+        json=mock_necessities_data,
+        request=httpx.Request("GET", "http://test.url"),
+    )
+    mock_async_client.return_value.__aenter__.return_value.get.return_value = (
+        mock_response
+    )
 
     response = client.get("/api/v1/prices/necessities-price")
 
@@ -48,11 +54,18 @@ def test_get_necessities_prices(mock_get, mock_necessities_data):
     assert data[1]["產品名稱"] == "味全林鳳營鮮乳"
 
 
-@patch("main.requests.get")
-def test_get_necessities_prices_with_query(mock_get, mock_necessities_data):
-    mock_response = mock_get.return_value
-    mock_response.status_code = 200
-    mock_response.json.return_value = mock_necessities_data
+@patch("src.prices.router.httpx.AsyncClient")
+def test_get_necessities_prices_with_query(
+    mock_async_client, mock_necessities_data
+):
+    mock_response = httpx.Response(
+        200,
+        json=mock_necessities_data,
+        request=httpx.Request("GET", "http://test.url"),
+    )
+    mock_async_client.return_value.__aenter__.return_value.get.return_value = (
+        mock_response
+    )
 
     response = client.get(
         "/api/v1/prices/necessities-price",
@@ -66,7 +79,7 @@ def test_get_necessities_prices_with_query(mock_get, mock_necessities_data):
     assert data[0]["產品名稱"] == "統一瑞穗高優質鮮乳"
 
 
-# @patch("main.requests.get")
+# @patch("src.prices.router.httpx.AsyncClient")
 # def test_get_necessities_prices_error_handling(mock_get):
 #     mock_response = mock_get.return_value
 #     mock_response.status_code = 400

--- a/backend/tests/prices/test_price_endpoint.py
+++ b/backend/tests/prices/test_price_endpoint.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import httpx
 import pytest

--- a/backend/tests/user/test_user_endpoint.py
+++ b/backend/tests/user/test_user_endpoint.py
@@ -1,7 +1,3 @@
-import os
-import shutil
-import time
-
 import pytest
 from fastapi.testclient import TestClient
 from jose import jwt

--- a/backend/tests/user/test_user_endpoint.py
+++ b/backend/tests/user/test_user_endpoint.py
@@ -1,10 +1,16 @@
+import os
+import shutil
+import time
+
 import pytest
 from fastapi.testclient import TestClient
 from jose import jwt
 from sqlalchemy import StaticPool, create_engine
 from sqlalchemy.orm import sessionmaker
 
-from main import Base, User, app, pwd_context, session_opener
+from main import app
+from src.database import Base, User, get_db
+from src.user.service import auth_service
 
 SECRET_KEY = "1892dhianiandowqd0n"
 ALGORITHM = "HS256"
@@ -23,7 +29,7 @@ TestingSessionLocal = sessionmaker(
 Base.metadata.create_all(bind=engine)
 
 
-def override_session_opener():
+def override_get_db():
     try:
         db = TestingSessionLocal()
         yield db
@@ -31,23 +37,23 @@ def override_session_opener():
         db.close()
 
 
-app.dependency_overrides[session_opener] = override_session_opener
+app.dependency_overrides[get_db] = override_get_db
 
 client = TestClient(app)
 
 
 @pytest.fixture(scope="module")
 def clear_users():
-    with next(override_session_opener()) as db:
+    with next(override_get_db()) as db:
         db.query(User).delete()
         db.commit()
 
 
 @pytest.fixture(scope="module")
 def test_user(clear_users):
-    hashed_password = pwd_context.hash("testpassword")
+    hashed_password = auth_service.get_password_hash("testpassword")
 
-    with next(override_session_opener()) as db:
+    with next(override_get_db()) as db:
         user = User(username="testuser", hashed_password=hashed_password)
         db.add(user)
         db.commit()
@@ -64,12 +70,13 @@ def test_token(test_user):
 
 
 def test_register_user():
+
     response = client.post(
         "/api/v1/users/register",
         json={"username": "newuser", "password": "newpassword"},
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 201
     data = response.json()
     assert data["username"] == "newuser"
 


### PR DESCRIPTION
## Purpose
Align CI, dependencies, and tests with the refactored backend architecture while re-enabling an AI-powered news search endpoint and improving test isolation and reliability.

## Changes
- CI configuration:
  - Trigger CI on additional branches (`develop`, `fix/integration-test`) for both push and PR events so non-main branches are validated.
  - Change the GitHub Actions runner from `ubuntu-latest` to `F74144781` to use a specific/self-hosted environment.

- Git ignore rules:
  - Keep ignoring `backend/news_database.db` and add ignores for `.coverage`, `coverage.xml`, `test.db`, `test-report.html`, and `backend/assets/**` to avoid committing test artifacts, coverage reports, temporary DBs, and built assets.

- Dependency tweak:
  - Relax `typing_extensions` from a pinned version to an unpinned requirement to reduce version conflicts and ease upgrades.

- Database repository:
  - Add `NewsArticleRepository.find_by_url(url: str)` to fetch an article by URL, enabling reuse for deduplication or direct lookups.

- News API and schemas:
  - Update `news/router.py`:
    - Import `NewsSearchResultSchema` and annotate `/search_news` with `response_model=list[NewsSearchResultSchema]`.
    - Replace the deprecated `/search_news` behavior (always 404) with a real implementation that constructs a `NewsProcessor` and returns `search_news_by_prompt(request.prompt)`.
  - Extend `news/schemas.py` with `NewsSearchResultSchema` containing `url`, `title`, `time`, and `content` to define a structured response for search results.

- News service logic:
  - Add `NewsProcessor._extract_keywords(prompt: str)`:
    - Use OpenAI Chat Completions (Chinese system prompt) to turn a free-form user prompt into concise search keywords and handle errors gracefully.
  - Add `NewsProcessor.search_news_by_prompt(prompt: str)`:
    - Extract keywords, call `_fetch_news_from_api(keywords, is_initial=False)`, scrape each article via `_scrape_article_details`, join content paragraphs into a single string, and return results sorted by `time` (newest first).

- News endpoint tests:
  - Refactor imports to use `src` modules:
    - Import `Base`, `NewsArticle`, `User`, `USER_NEWS_ASSOCIATION_TABLE`, and `get_db` from `src.database`.
    - Import `NewsSummaryRequestSchema` from `src.news.schemas` and `auth_service` from `src.user.service`.
    - Only import `app` from `main`.
  - Update dependency override to target `get_db` instead of `session_opener`, matching the new FastAPI dependency pattern.
  - Use `auth_service.get_password_hash` instead of `pwd_context.hash` to mirror production password hashing.
  - Add a session-scope `cleanup` fixture to remove `./test.db` after tests, keeping the workspace clean.
  - Adjust OpenAI mocking to patch `src.news.service.OpenAI` rather than `main.OpenAI`, aligning with where the client is instantiated.
  - Update `test_search_news`:
    - Mock keyword extraction to return `"雞蛋 價格"` to reflect the Chinese keyword-extraction logic.
    - Patch `NewsProcessor._fetch_news_from_api` in `src.news.service` instead of a top-level helper in `main`.
    - Patch `src.news.service.requests.get` and configure a mock response with HTML and `raise_for_status`.
    - Add assertions to verify `_fetch_news_from_api` is called with `"雞蛋 價格", is_initial=False` and that `requests.get` is invoked with the expected URL and timeout.
  - Fix summary test to use `NewsSummaryRequestSchema` (correct name) instead of `NewsSumaryRequestSchema`.

- Prices endpoint tests:
  - Introduce `httpx` usage and adjust mocks:
    - Import `httpx` and `AsyncMock` (even if not currently used).
    - Replace `@patch("main.requests.get")` with `@patch("src.prices.router.httpx.AsyncClient")` to match the async HTTP client implementation.
    - Build `httpx.Response` objects and wire them into `AsyncClient().__aenter__().get.return_value` so the tests exercise the same async flow as production.
  - Update the commented-out error-handling test’s patch target to the new `httpx.AsyncClient` path for consistency.

- User endpoint tests:
  - Refactor imports to use `src.database.Base`, `src.database.User`, `src.database.get_db`, and `src.user.service.auth_service`, keeping `app` from `main`.
  - Rename the DB override to `override_get_db` and map `app.dependency_overrides[get_db] = override_get_db`, aligning with the new dependency.
  - Update fixtures to use `override_get_db` instead of `override_session_opener` and create hashed passwords via `auth_service.get_password_hash`.
  - Change `test_register_user` to expect HTTP 201 instead of 200, matching the endpoint’s “Created” semantics.
